### PR TITLE
Add support for GroundTruth messages

### DIFF
--- a/src/OSMPTraceFilePlayer.h
+++ b/src/OSMPTraceFilePlayer.h
@@ -72,6 +72,7 @@ using namespace std;
 #include "osi-utilities/tracefile/Reader.h"
 #include "osi_sensordata.pb.h"
 #include "osi_sensorview.pb.h"
+#include "osi_groundtruth.pb.h"
 
 /* FMU Class */
 class COSMPTraceFilePlayer
@@ -226,8 +227,11 @@ class COSMPTraceFilePlayer
     /* Protocol Buffer Accessors */
     void SetFmiSensorViewOut(const osi3::SensorView& data);
     void SetFmiSensorDataOut(const osi3::SensorData& data);
+    void SetFmiGroundTruthOut(const osi3::GroundTruth& data);
 
     void ResetFmiSensorViewOut();
     void ResetFmiSensorDataOut();
+    void ResetFmiGroundTruthOut();
 };
 #endif
+


### PR DESCRIPTION
CI Checks need https://github.com/openMSL/sl-5-5-osi-trace-file-player/pull/23 first

**Reference to a related issue in the repository**
#20
**Add a description**
Adds the capability to playback GroundTruth as well. I did not add all other unsupported messages yet as I would suggest to refactor the whole `FMI_INTEGER_SENSORVIEW_OUT_xxx` code repetititon (in terms of using the sensorview connector for everything with a lot of `SetFmiyyyOut` functions) . Something like [fmu4cpp](https://github.com/Ecos-platform/fmu4cpp) *could* help. 

Tested with openmcx and the network proxy.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.


